### PR TITLE
Fixes duplicate message entries appearing when replying

### DIFF
--- a/controllers/MailController.php
+++ b/controllers/MailController.php
@@ -128,6 +128,8 @@ class MailController extends Controller
         // Reply Form
         $replyForm = new ReplyForm(['model' => $message]);
         if ($replyForm->load(Yii::$app->request->post()) && $replyForm->save()) {
+            if (!date_create($replyForm->reply->created_at))
+                $replyForm->reply->created_at = time();
             return $this->asJson([
                 'success' => true,
                 'content' => ConversationEntry::widget(['entry' => $replyForm->reply])

--- a/resources/js/humhub.mail.wall.js
+++ b/resources/js/humhub.mail.wall.js
@@ -270,7 +270,7 @@ humhub.module('mail.wall', function(module, require, $) {
     };
 
     var getRootView = function() {
-        return Widget.instance('#mail-conversation-root');
+        return Widget.instance('mail-conversation-root');
     }
 
     var init = function() {


### PR DESCRIPTION
When replying to a message, the user that initiated the action will get
their message duplicated until the page is reloaded.
The user receives the message submit event and the reply and event
trigger action enter the same critical section.
Especially noticeable using the Push Service : http://docs.humhub.org/admin-push-updates.html
This wraps a basic mutex around those sensitive sections.
See: https://github.com/Wizcorp/locks