### PR TITLE
#240 fixed apostrophe encode in mails subject

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 - Fix #224: Fix preview message in sidebar
 - Fix #231: CLI error when no REST module is installed
 - Fix #230: Fix notifications of new Conversation vs Message entry
+- Fix #240: Fix apostrophe encode in mail
 
 2.0.7  (April 8, 2021)
 ----------------------

--- a/models/MessageNotification.php
+++ b/models/MessageNotification.php
@@ -172,7 +172,7 @@ class MessageNotification extends Model
 
     protected function getSubject(): string
     {
-        $params = ['{senderName}' => Html::encode($this->getEntrySender()->displayName)];
+        $params = ['{senderName}' => $this->getEntrySender()->displayName];
 
         return $this->isNewConversation
             ? Yii::t('MailModule.models_Message', 'New conversation from {senderName}', $params)


### PR DESCRIPTION
I removed Html::encode from getSubject(). It is only used to set mail's subject and unnecessary because mailing services will do the encoding themselves, while double encoding breaks some characters, see issue #240.