### PR TITLE
Remove new lines in notificationInbox view

### DIFF
--- a/widgets/views/notificationInbox.php
+++ b/widgets/views/notificationInbox.php
@@ -36,4 +36,3 @@ $canStartConversation = Yii::$app->user->can(StartConversation::class);
         </li>
     </ul>
 </div>
-


### PR DESCRIPTION
When a custom module adds a button to NotificationArea, there is a space between the mail module icon and the button, see screenshot.

![Screenshot 2023-05-31 at 23-23-41 Übersicht - Felix Hahn Development](https://github.com/humhub/mail/assets/84990763/d5bef9ee-f0ea-4996-82db-51d4d09662cd)
