### PR TITLE
Replaced Yii AssetBundle with Humhub one and removed $defered

### DIFF
--- a/assets/MailMessengerAsset.php
+++ b/assets/MailMessengerAsset.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace humhub\modules\mail\assets;
 
-use humhub\modules\mail\helpers\Url;
-use yii\web\AssetBundle;
+use humhub\components\assets\AssetBundle;
 
 /**
  * Created by PhpStorm.
@@ -10,11 +10,8 @@ use yii\web\AssetBundle;
  * Date: 29.07.2018
  * Time: 08:19
  */
-
 class MailMessengerAsset extends AssetBundle
 {
-    public $defer = true;
-
     public $sourcePath = '@mail/resources/js';
 
     public $publishOptions = [

--- a/assets/MailNotificationAsset.php
+++ b/assets/MailNotificationAsset.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace humhub\modules\mail\assets;
 
+use humhub\components\assets\AssetBundle;
 use humhub\modules\mail\helpers\Url;
-use yii\web\AssetBundle;
 
 /**
  * Created by PhpStorm.
@@ -10,11 +11,8 @@ use yii\web\AssetBundle;
  * Date: 29.07.2018
  * Time: 08:19
  */
-
 class MailNotificationAsset extends AssetBundle
 {
-    public $defer = true;
-
     public $sourcePath = '@mail/resources/js';
 
     public $publishOptions = [

--- a/assets/MailStyleAsset.php
+++ b/assets/MailStyleAsset.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace humhub\modules\mail\assets;
 
-use humhub\modules\mail\helpers\Url;
-use yii\web\AssetBundle;
+use humhub\components\assets\AssetBundle;
 
 /**
  * Created by PhpStorm.
@@ -10,11 +10,8 @@ use yii\web\AssetBundle;
  * Date: 29.07.2018
  * Time: 08:19
  */
-
 class MailStyleAsset extends AssetBundle
 {
-    public $defer = true;
-
     public $sourcePath = '@mail/resources/css';
 
     public $publishOptions = [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
+
+Unreleased
+-------------------------
 - Fix #348: Remove new lines in notificationInbox view
+- Fix #349: Assets now extending `humhub\components\assets\AssetBundle` instead of `yii\web\AssetBundle`
 
 3.0.2  (August 17, 2023)
 -------------------------
@@ -15,8 +19,7 @@ Changelog
 - Fix #312: Visibility of scroll down button
 - Fix #313: Display state(joined/left) messages in inbox
 - Fix #322: Fix color of hover or active sub headline
-- Fix #335: Remove new lines in notificationInbox view 
-
+- Fix #335: Remove new lines in notificationInbox view
 
 3.0.0-beta.1  (March 13, 2023)
 ------------------------------
@@ -26,7 +29,7 @@ Changelog
 - Fix #283: Add markdown-render class to Markdown text for Translator module to work
 - Fix #272: Exclude invisible users from recipients
 - Fix #280: Update styles of message block
-- Enh #274: Browser Tab Indicator on New Unread Message 
+- Enh #274: Browser Tab Indicator on New Unread Message
 
 2.1.0  (December 7, 2021)
 -------------------------
@@ -44,7 +47,7 @@ Changelog
 2.0.6  (April 8, 2021)
 ----------------------
 - Enh: Use controller config for not intercepted actions
-- Enh #217: RESTFul API Module Support 
+- Enh #217: RESTFul API Module Support
 
 2.0.5 - January 21, 2021
 ------------------------
@@ -102,46 +105,38 @@ Changelog
 
 1.0.15 - March 28, 2020
 -----------------------
-- Fix #173: New message creation notification fails 
-
+- Fix #173: New message creation notification fails
 
 1.0.14 - March 17, 2020
 -----------------------
 - Chg: Internal change in message creation order
 - Enh: Updated translations
 
-
 1.0.13 - February 12, 2020
 -----------------------
 - Fix: Max. conversation check not disabled
 - Enh: Updated translations
 
-
 1.0.12 - October 16, 2019
 -----------------------
 - Enh: 1.4 nonce compatibility
-
 
 1.0.11 - June 15, 2019
 -----------------------
 - Enh: Updated translations
 - Enh: Improved docs
 
-
 1.0.10 - March 27, 2019
 -----------------------
 - Fix: #155 Mail duplication in Mail Dropdown after repeated clicks
-
 
 1.0.9 - March 14, 2019
 -----------------------
 - Enh: Use of `Richtext::preview` instead of `MarkdownPreview`
 
-
 1.0.7 - March 11, 2019
 -----------------------
 - Enh: Added new conversation restrictions
-
 
 1.0.6 - November 16, 2018
 -----------------------
@@ -149,32 +144,26 @@ Changelog
 - Fix: #79 Sender langauge used for e-mail notification instead of receiver language
 - Fix: #147 Send message button in profile missing margin
 
-
 1.0.5 - November 2, 2018
 -----------------------
 - Enh: Updated translations
 - Enh: Added font less option in e-mail templates (@rekollekt)
 
-
 1.0.4 - October 5, 2018
 -----------------------
 - Fix: IE11 compatibility issue
-
 
 1.0.3 - October 4, 2018
 -----------------------
 - Fix: #147 Message button size on profile
 
-
 1.0.2 - September 27, 2018
 -----------------------
 - Fix: Files are not attached to MessageEntry
 
-
 1.0.1 - September 26, 2018
 -----------------------
 - Fix: Message preview encoding issue
-
 
 1.0.0 - September 26, 2018
 -----------------------
@@ -183,21 +172,17 @@ Changelog
 - Enh: Added conversation user list to mail overview
 - Chng: Major refactoring
 
-
 0.9.14 - July 2, 2018
 -----------------------
 - Fix: PHP 7.2 compatibility issues
-
 
 0.9.13 - June 13, 2018
 ----------------------
 - Enh: Added option to hide main navigation "Message" entry
 
-
 0.9.9 - May 16, 2018
 ----------------------
 - Enh: Added global `StartConversation` permission
-
 
 0.9.8 - October 4, 2017
 ----------------------


### PR DESCRIPTION
The `public $defered = true` was useless because the asset classes where extending `yii\web\AssetBundle`.
And now that they extends `humhub\components\assets\AssetBundle` it's still useless as `true` is the default value.