### PR TITLE
Don't display date badge twice after update a message

### DIFF
--- a/controllers/MailController.php
+++ b/controllers/MailController.php
@@ -382,7 +382,10 @@ class MailController extends Controller
             $entry->fileManager->attach(Yii::$app->request->post('MessageEntry')['files'] ?? null);
             return $this->asJson([
                 'success' => true,
-                'content' => ConversationEntry::widget(['entry' => $entry])
+                'content' => ConversationEntry::widget([
+                    'entry' => $entry,
+                    'showDateBadge' => false
+                ])
             ]);
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 3.1.2 (Unreleased)
 ----------------------
 - Enh #353: Tests for `next` version
+- Fix #354: Don't display date badge twice after update a message
 
 3.1.1  (September 19, 2023)
 ---------------------------


### PR DESCRIPTION
Issue: https://github.com/humhub/humhub/issues/6589