### PR TITLE
Allow message title and body be provided by GET request for new messages

### DIFF
--- a/controllers/MailController.php
+++ b/controllers/MailController.php
@@ -313,9 +313,9 @@ class MailController extends Controller
      * Creates a new Message
      * and redirects to it.
      */
-    public function actionCreate($userGuid = null)
+    public function actionCreate($userGuid = null, ?string $title = null, ?string $message = null)
     {
-        $model = new CreateMessage(['recipient' => [$userGuid]]);
+        $model = new CreateMessage(['recipient' => [$userGuid], 'title' => $title, 'message' => $message]);
 
         // Preselect user if userGuid is given
         if ($userGuid) {


### PR DESCRIPTION
Currently, when creating a new message, `title` and `message` cannot easily be pre-filled. 

The proposed enhancements allow to define `titel` and `message` to be passed with the GET request:

`/mail/mail/create?ajax=1&userGuid=eee3b53b-c528-4ee7-9217-deca6d104755&title=subject&message=text`